### PR TITLE
Split out RETRIEVE into READ_ONE and READ_MANY

### DIFF
--- a/src/default-reducers/read-many.js
+++ b/src/default-reducers/read-many.js
@@ -25,10 +25,7 @@ export function retrieveManyFail(idAttr, state) {
 
 export function retrieveManySucceed(idAttr, state, action) {
   const resources = action.resources;
-  // This needs to use `idAttr`.
   const ids = resources.map(r => r[idAttr]);
-
-
   const replace = typeof action.replace !== 'undefined' ? action.replace : true;
 
   let newResources;

--- a/src/generate-action-types.js
+++ b/src/generate-action-types.js
@@ -16,8 +16,8 @@ export default (resourceName, pluralForm, supportedActions) => {
   const {create, readOne, readMany, update, del} = supportedActions;
 
   const createTypes = create ? mapConstant(capitalResourceName, 'CREATE') : {};
-  const readOneTypes = readOne ? mapConstant(capitalResourceName, 'RETRIEVE') : {};
-  const readManyTypes = readMany ? mapConstant(capitalPluralName, 'RETRIEVE') : {};
+  const readOneTypes = readOne ? mapConstant(capitalResourceName, 'READ_ONE') : {};
+  const readManyTypes = readMany ? mapConstant(capitalPluralName, 'READ_MANY') : {};
   const updateTypes = update ? mapConstant(capitalResourceName, 'UPDATE') : {};
   const deleteTypes = del ? mapConstant(capitalResourceName, 'DELETE') : {};
 

--- a/src/generate-reducer.js
+++ b/src/generate-reducer.js
@@ -18,19 +18,19 @@ function getHandlers({customHandlers, resourceName, pluralForm, supportedActions
   } : {};
 
   const readOneHandlers = readOne ? {
-    [`RETRIEVE_${capitalResourceName}`]: defaultReducers.retrieveOne.bind(null, idAttr),
-    [`RETRIEVE_${capitalResourceName}_FAIL`]: defaultReducers.retrieveOneFail.bind(null, idAttr),
-    [`RETRIEVE_${capitalResourceName}_SUCCEED`]: defaultReducers.retrieveOneSucceed.bind(null, idAttr),
-    [`RETRIEVE_${capitalResourceName}_ABORT`]: defaultReducers.retrieveOneAbort.bind(null, idAttr),
-    [`RETRIEVE_${capitalResourceName}_RESET`]: defaultReducers.retrieveOneReset.bind(null, idAttr)
+    [`READ_ONE_${capitalResourceName}`]: defaultReducers.retrieveOne.bind(null, idAttr),
+    [`READ_ONE_${capitalResourceName}_FAIL`]: defaultReducers.retrieveOneFail.bind(null, idAttr),
+    [`READ_ONE_${capitalResourceName}_SUCCEED`]: defaultReducers.retrieveOneSucceed.bind(null, idAttr),
+    [`READ_ONE_${capitalResourceName}_ABORT`]: defaultReducers.retrieveOneAbort.bind(null, idAttr),
+    [`READ_ONE_${capitalResourceName}_RESET`]: defaultReducers.retrieveOneReset.bind(null, idAttr)
   } : {};
 
   const readManyHandlers = readMany ? {
-    [`RETRIEVE_${capitalPluralName}`]: defaultReducers.retrieveMany.bind(null, idAttr),
-    [`RETRIEVE_${capitalPluralName}_FAIL`]: defaultReducers.retrieveManyFail.bind(null, idAttr),
-    [`RETRIEVE_${capitalPluralName}_SUCCEED`]: defaultReducers.retrieveManySucceed.bind(null, idAttr),
-    [`RETRIEVE_${capitalPluralName}_ABORT`]: defaultReducers.retrieveManyAbort.bind(null, idAttr),
-    [`RETRIEVE_${capitalPluralName}_RESET`]: defaultReducers.retrieveManyReset.bind(null, idAttr)
+    [`READ_MANY_${capitalPluralName}`]: defaultReducers.retrieveMany.bind(null, idAttr),
+    [`READ_MANY_${capitalPluralName}_FAIL`]: defaultReducers.retrieveManyFail.bind(null, idAttr),
+    [`READ_MANY_${capitalPluralName}_SUCCEED`]: defaultReducers.retrieveManySucceed.bind(null, idAttr),
+    [`READ_MANY_${capitalPluralName}_ABORT`]: defaultReducers.retrieveManyAbort.bind(null, idAttr),
+    [`READ_MANY_${capitalPluralName}_RESET`]: defaultReducers.retrieveManyReset.bind(null, idAttr)
   } : {};
 
   const updateHandlers = update ? {

--- a/test/unit/action-types.js
+++ b/test/unit/action-types.js
@@ -18,20 +18,20 @@ describe('actionTypes', function() {
 
   describe('retrieveOne', () => {
     const actionTypes = simpleResource('hello').actionTypes;
-    expect(actionTypes.RETRIEVE_HELLO).to.equal('RETRIEVE_HELLO');
-    expect(actionTypes.RETRIEVE_HELLO_SUCCEED).to.equal('RETRIEVE_HELLO_SUCCEED');
-    expect(actionTypes.RETRIEVE_HELLO_FAIL).to.equal('RETRIEVE_HELLO_FAIL');
-    expect(actionTypes.RETRIEVE_HELLO_ABORT).to.equal('RETRIEVE_HELLO_ABORT');
-    expect(actionTypes.RETRIEVE_HELLO_RESET).to.equal('RETRIEVE_HELLO_RESET');
+    expect(actionTypes.READ_ONE_HELLO).to.equal('READ_ONE_HELLO');
+    expect(actionTypes.READ_ONE_HELLO_SUCCEED).to.equal('READ_ONE_HELLO_SUCCEED');
+    expect(actionTypes.READ_ONE_HELLO_FAIL).to.equal('READ_ONE_HELLO_FAIL');
+    expect(actionTypes.READ_ONE_HELLO_ABORT).to.equal('READ_ONE_HELLO_ABORT');
+    expect(actionTypes.READ_ONE_HELLO_RESET).to.equal('READ_ONE_HELLO_RESET');
   });
 
   describe('retrieveMany', () => {
     const actionTypes = simpleResource('hello').actionTypes;
-    expect(actionTypes.RETRIEVE_HELLOS).to.equal('RETRIEVE_HELLOS');
-    expect(actionTypes.RETRIEVE_HELLOS_SUCCEED).to.equal('RETRIEVE_HELLOS_SUCCEED');
-    expect(actionTypes.RETRIEVE_HELLOS_FAIL).to.equal('RETRIEVE_HELLOS_FAIL');
-    expect(actionTypes.RETRIEVE_HELLOS_ABORT).to.equal('RETRIEVE_HELLOS_ABORT');
-    expect(actionTypes.RETRIEVE_HELLOS_RESET).to.equal('RETRIEVE_HELLOS_RESET');
+    expect(actionTypes.READ_MANY_HELLOS).to.equal('READ_MANY_HELLOS');
+    expect(actionTypes.READ_MANY_HELLOS_SUCCEED).to.equal('READ_MANY_HELLOS_SUCCEED');
+    expect(actionTypes.READ_MANY_HELLOS_FAIL).to.equal('READ_MANY_HELLOS_FAIL');
+    expect(actionTypes.READ_MANY_HELLOS_ABORT).to.equal('READ_MANY_HELLOS_ABORT');
+    expect(actionTypes.READ_MANY_HELLOS_RESET).to.equal('READ_MANY_HELLOS_RESET');
   });
 
   describe('update', () => {
@@ -63,24 +63,24 @@ describe('actionTypes', function() {
       }
     }).actionTypes;
     expect(_.size(actionTypes)).to.equal(5);
-    expect(actionTypes.RETRIEVE_HELLOS).to.equal('RETRIEVE_HELLOS');
-    expect(actionTypes.RETRIEVE_HELLOS_SUCCEED).to.equal('RETRIEVE_HELLOS_SUCCEED');
-    expect(actionTypes.RETRIEVE_HELLOS_FAIL).to.equal('RETRIEVE_HELLOS_FAIL');
-    expect(actionTypes.RETRIEVE_HELLOS_ABORT).to.equal('RETRIEVE_HELLOS_ABORT');
-    expect(actionTypes.RETRIEVE_HELLOS_RESET).to.equal('RETRIEVE_HELLOS_RESET');
+    expect(actionTypes.READ_MANY_HELLOS).to.equal('READ_MANY_HELLOS');
+    expect(actionTypes.READ_MANY_HELLOS_SUCCEED).to.equal('READ_MANY_HELLOS_SUCCEED');
+    expect(actionTypes.READ_MANY_HELLOS_FAIL).to.equal('READ_MANY_HELLOS_FAIL');
+    expect(actionTypes.READ_MANY_HELLOS_ABORT).to.equal('READ_MANY_HELLOS_ABORT');
+    expect(actionTypes.READ_MANY_HELLOS_RESET).to.equal('READ_MANY_HELLOS_RESET');
   });
 
   describe('passing in various names', () => {
     const helloThereActionTypes = simpleResource('hello there').actionTypes;
-    expect(helloThereActionTypes.RETRIEVE_HELLO_THERES).to.equal('RETRIEVE_HELLO_THERES');
+    expect(helloThereActionTypes.READ_MANY_HELLO_THERES).to.equal('READ_MANY_HELLO_THERES');
 
     const bookCaseActionTypes = simpleResource('bookCase').actionTypes;
-    expect(bookCaseActionTypes.RETRIEVE_BOOK_CASES).to.equal('RETRIEVE_BOOK_CASES');
+    expect(bookCaseActionTypes.READ_MANY_BOOK_CASES).to.equal('READ_MANY_BOOK_CASES');
 
     const jsonViewerActionTypes = simpleResource('JSONViewer').actionTypes;
-    expect(jsonViewerActionTypes.RETRIEVE_JSON_VIEWERS).to.equal('RETRIEVE_JSON_VIEWERS');
+    expect(jsonViewerActionTypes.READ_MANY_JSON_VIEWERS).to.equal('READ_MANY_JSON_VIEWERS');
 
     const catPersonActionTypes = simpleResource('cat-person', {pluralForm: 'cat-people'}).actionTypes;
-    expect(catPersonActionTypes.RETRIEVE_CAT_PEOPLE).to.equal('RETRIEVE_CAT_PEOPLE');
+    expect(catPersonActionTypes.READ_MANY_CAT_PEOPLE).to.equal('READ_MANY_CAT_PEOPLE');
   });
 });

--- a/test/unit/reducers/read-many.js
+++ b/test/unit/reducers/read-many.js
@@ -1,10 +1,10 @@
 import simpleResource, {xhrStatuses} from '../../../src';
 
 describe('reducers: readMany', function() {
-  it('should handle `RETRIEVE_HELLOS`', () => {
+  it('should handle `READ_MANY_HELLOS`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS'
+      type: 'READ_MANY_HELLOS'
     });
 
     expect(reduced).to.deep.equal({
@@ -17,10 +17,10 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_FAIL`', () => {
+  it('should handle `READ_MANY_HELLOS_FAIL`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS_FAIL'
+      type: 'READ_MANY_HELLOS_FAIL'
     });
 
     expect(reduced).to.deep.equal({
@@ -33,7 +33,7 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_SUCCEED`', () => {
+  it('should handle `READ_MANY_HELLOS_SUCCEED`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -45,7 +45,7 @@ describe('reducers: readMany', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS_SUCCEED',
+      type: 'READ_MANY_HELLOS_SUCCEED',
       resources: [
         {id: 2, hungry: true, pasta: 'yespls'},
         {id: 100, hungry: false},
@@ -76,7 +76,7 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_SUCCEED` with `replace: false`', () => {
+  it('should handle `READ_MANY_HELLOS_SUCCEED` with `replace: false`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -88,7 +88,7 @@ describe('reducers: readMany', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS_SUCCEED',
+      type: 'READ_MANY_HELLOS_SUCCEED',
       replace: false,
       resources: [
         {id: 2, hungry: true, pasta: 'yespls'},
@@ -122,12 +122,12 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_SUCCEED` with a custom idAttribute', () => {
+  it('should handle `READ_MANY_HELLOS_SUCCEED` with a custom idAttribute', () => {
     const result = simpleResource('hello', {
       idAttribute: 'namePls'
     });
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS_SUCCEED',
+      type: 'READ_MANY_HELLOS_SUCCEED',
       resources: [
         {namePls: 2, hungry: true, pasta: 'yespls'},
         {namePls: 100, hungry: false},
@@ -158,10 +158,10 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_ABORT`', () => {
+  it('should handle `READ_MANY_HELLOS_ABORT`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLOS_ABORT'
+      type: 'READ_MANY_HELLOS_ABORT'
     });
 
     expect(reduced).to.deep.equal({
@@ -174,7 +174,7 @@ describe('reducers: readMany', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLOS_RESET`', () => {
+  it('should handle `READ_MANY_HELLOS_RESET`', () => {
     const result = simpleResource('hello');
 
     // We set some value on `retrievingStatus` to check that this nulls it
@@ -189,7 +189,7 @@ describe('reducers: readMany', function() {
       ...result.initialState,
       ...resourcesListMetaState
     }, {
-      type: 'RETRIEVE_HELLOS_RESET'
+      type: 'READ_MANY_HELLOS_RESET'
     });
 
     expect(reduced).to.deep.equal({

--- a/test/unit/reducers/read-one.js
+++ b/test/unit/reducers/read-one.js
@@ -1,10 +1,10 @@
 import simpleResource, {xhrStatuses} from '../../../src';
 
 describe('reducers: readOne', function() {
-  it('should handle `RETRIEVE_HELLO`', () => {
+  it('should handle `READ_ONE_HELLO`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO',
+      type: 'READ_ONE_HELLO',
       id: 3
     });
 
@@ -22,10 +22,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_FAIL`', () => {
+  it('should handle `READ_ONE_HELLO_FAIL`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_FAIL',
+      type: 'READ_ONE_HELLO_FAIL',
       id: 3
     });
 
@@ -43,7 +43,7 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_SUCCEED`', () => {
+  it('should handle `READ_ONE_HELLO_SUCCEED`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -53,7 +53,7 @@ describe('reducers: readOne', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_SUCCEED',
+      type: 'READ_ONE_HELLO_SUCCEED',
       id: 3,
       resource: {
         id: 3,
@@ -80,7 +80,7 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_SUCCEED` with `replace: false`', () => {
+  it('should handle `READ_ONE_HELLO_SUCCEED` with `replace: false`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -90,7 +90,7 @@ describe('reducers: readOne', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_SUCCEED',
+      type: 'READ_ONE_HELLO_SUCCEED',
       id: 3,
       replace: false,
       resource: {
@@ -119,12 +119,12 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_SUCCEED` with a custom idAttribute', () => {
+  it('should handle `READ_ONE_HELLO_SUCCEED` with a custom idAttribute', () => {
     const result = simpleResource('hello', {
       idAttribute: 'whatPls'
     });
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_SUCCEED',
+      type: 'READ_ONE_HELLO_SUCCEED',
       whatPls: 3,
       resource: {
         whatPls: 3,
@@ -151,10 +151,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_ABORT`', () => {
+  it('should handle `READ_ONE_HELLO_ABORT`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_ABORT',
+      type: 'READ_ONE_HELLO_ABORT',
       id: 3
     });
 
@@ -172,10 +172,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `RETRIEVE_HELLO_RESET`', () => {
+  it('should handle `READ_ONE_HELLO_RESET`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'RETRIEVE_HELLO_RESET',
+      type: 'READ_ONE_HELLO_RESET',
       id: 3
     });
 


### PR DESCRIPTION
This lib uses two action types for read one and read many. Previously, they were like this:

| Read # | Action type |
|--------|-------------|
| One      | `RETRIEVE_THING` |
| Many    | `RETRIEVE_THINGS` |

This PR makes it so that that the types are now:

| Read # | Action type |
|--------|-------------|
| One      | `READ_ONE_THING` |
| Many    | `READ_MANY_THINGS` |