### PR TITLE
Remove "_ONE" prefix from action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ for each of the built-in CRUD operations:
 `READ_MANY_BOOKS`
 
 // These operate on a single resource
-`READ_ONE_BOOK`
+`READ_BOOK`
 `DELETE_BOOK`
 `UPDATE_BOOK`
 `CREATE_BOOK`
@@ -541,11 +541,11 @@ redux-simple-resource creates CRUD-related action types for you.
 The action types for read one, for instance, are:
 
 ```js
-`READ_ONE_BOOK`
-`READ_ONE_BOOK_FAIL`
-`READ_ONE_BOOK_ABORT`
-`READ_ONE_BOOK_SUCCEED`
-`READ_ONE_BOOK_RESET`
+`READ_BOOK`
+`READ_BOOK_FAIL`
+`READ_BOOK_ABORT`
+`READ_BOOK_SUCCEED`
+`READ_BOOK_RESET`
 ```
 
 These five types reflect the five [XHR Statuses](#xhr-statuses), as each of
@@ -590,7 +590,7 @@ an `xhrStatuses.PENDING` state.
 These are the start action types:
 
 ```js
-`READ_ONE_{RESOURCE}`
+`READ_{RESOURCE}`
 `READ_MANY_{PLURAL_RESOURCE}`
 `CREATE_{RESOURCE}`
 `UPDATE_{RESOURCE}`
@@ -601,7 +601,7 @@ An example start action type is:
 
 ```js
 {
-  type: READ_ONE_BOOK,
+  type: READ_BOOK,
   id: 5
 }
 ```
@@ -614,7 +614,7 @@ This will update the metadata for this particular action to be in an
 These are the five FAIL action types:
 
 ```js
-`READ_ONE_{RESOURCE}_FAIL`
+`READ_{RESOURCE}_FAIL`
 `READ_MANY_{PLURAL_RESOURCE}_FAIL`
 `CREATE_{RESOURCE}_FAIL`
 `UPDATE_{RESOURCE}_FAIL`
@@ -625,7 +625,7 @@ An example fail action type is:
 
 ```js
 {
-  type: READ_ONE_BOOK_FAIL,
+  type: READ_BOOK_FAIL,
   id: 5
 }
 ```
@@ -636,7 +636,7 @@ This will update the metadata for this particular action to be in an
 `xhrStatuses.ABORTED` state.
 
 ```js
-`READ_ONE_{RESOURCE}_ABORT`
+`READ_{RESOURCE}_ABORT`
 `READ_MANY_{PLURAL_RESOURCE}_ABORT`
 `CREATE_{RESOURCE}_ABORT`
 `UPDATE_{RESOURCE}_ABORT`
@@ -664,7 +664,7 @@ Example success actions are:
 
 ```js
 {
-  type: 'UPDATE_ONE_BOOK_SUCCESS',
+  type: 'UPDATE_BOOK_SUCCESS',
   id: 10,
   resource: {
     id: 10,
@@ -687,7 +687,7 @@ Example success actions are:
 
 ```js
 {
-  type: 'DELETE_ONE_BOOK_SUCCESS',
+  type: 'DELETE_BOOK_SUCCESS',
   id: 10
 }
 ```
@@ -705,7 +705,7 @@ An example reset action is:
 
 ```js
 {
-  type: 'DELETE_ONE_BOOK_RESET',
+  type: 'DELETE_BOOK_RESET',
   id: 10
 }
 ```
@@ -838,9 +838,9 @@ default one. For instance,
 
 ```js
 // Dispatch the default action
-dispatch({type: 'READ_ONE_BOOK_SUCCESS', id: 5});
+dispatch({type: 'READ_BOOK_SUCCESS', id: 5});
 // Dispatch your default action
-dispatch({type: 'READ_ONE_BOOK_SUCCESS_EXTRA_THINGS', id: 5});
+dispatch({type: 'READ_BOOK_SUCCESS_EXTRA_THINGS', id: 5});
 ```
 
 If you're worried about performance, give it a try. If you can demonstrate that

--- a/src/generate-action-types.js
+++ b/src/generate-action-types.js
@@ -16,7 +16,7 @@ export default (resourceName, pluralForm, supportedActions, customTypes) => {
   const {create, readOne, readMany, update, del} = supportedActions;
 
   const createTypes = create ? mapConstant(capitalResourceName, 'CREATE') : {};
-  const readOneTypes = readOne ? mapConstant(capitalResourceName, 'READ_ONE') : {};
+  const readOneTypes = readOne ? mapConstant(capitalResourceName, 'READ') : {};
   const readManyTypes = readMany ? mapConstant(capitalPluralName, 'READ_MANY') : {};
   const updateTypes = update ? mapConstant(capitalResourceName, 'UPDATE') : {};
   const deleteTypes = del ? mapConstant(capitalResourceName, 'DELETE') : {};

--- a/src/generate-reducer.js
+++ b/src/generate-reducer.js
@@ -24,11 +24,11 @@ function getActionReducers({actionReducers, resourceName, pluralForm, supportedA
   } : {};
 
   const readOneReducers = readOne ? {
-    [`READ_ONE_${capitalResourceName}`]: defaultReducers.retrieveOne.bind(null, idAttr),
-    [`READ_ONE_${capitalResourceName}_FAIL`]: defaultReducers.retrieveOneFail.bind(null, idAttr),
-    [`READ_ONE_${capitalResourceName}_SUCCEED`]: defaultReducers.retrieveOneSucceed.bind(null, idAttr),
-    [`READ_ONE_${capitalResourceName}_ABORT`]: defaultReducers.retrieveOneAbort.bind(null, idAttr),
-    [`READ_ONE_${capitalResourceName}_RESET`]: defaultReducers.retrieveOneReset.bind(null, idAttr)
+    [`READ_${capitalResourceName}`]: defaultReducers.retrieveOne.bind(null, idAttr),
+    [`READ_${capitalResourceName}_FAIL`]: defaultReducers.retrieveOneFail.bind(null, idAttr),
+    [`READ_${capitalResourceName}_SUCCEED`]: defaultReducers.retrieveOneSucceed.bind(null, idAttr),
+    [`READ_${capitalResourceName}_ABORT`]: defaultReducers.retrieveOneAbort.bind(null, idAttr),
+    [`READ_${capitalResourceName}_RESET`]: defaultReducers.retrieveOneReset.bind(null, idAttr)
   } : {};
 
   const readManyReducers = readMany ? {

--- a/test/unit/action-types.js
+++ b/test/unit/action-types.js
@@ -21,11 +21,11 @@ describe('actionTypes', function() {
   describe('retrieveOne', () => {
     it('should have the right actionTypes', () => {
       const actionTypes = simpleResource('hello').actionTypes;
-      expect(actionTypes.READ_ONE_HELLO).to.equal('READ_ONE_HELLO');
-      expect(actionTypes.READ_ONE_HELLO_SUCCEED).to.equal('READ_ONE_HELLO_SUCCEED');
-      expect(actionTypes.READ_ONE_HELLO_FAIL).to.equal('READ_ONE_HELLO_FAIL');
-      expect(actionTypes.READ_ONE_HELLO_ABORT).to.equal('READ_ONE_HELLO_ABORT');
-      expect(actionTypes.READ_ONE_HELLO_RESET).to.equal('READ_ONE_HELLO_RESET');
+      expect(actionTypes.READ_HELLO).to.equal('READ_HELLO');
+      expect(actionTypes.READ_HELLO_SUCCEED).to.equal('READ_HELLO_SUCCEED');
+      expect(actionTypes.READ_HELLO_FAIL).to.equal('READ_HELLO_FAIL');
+      expect(actionTypes.READ_HELLO_ABORT).to.equal('READ_HELLO_ABORT');
+      expect(actionTypes.READ_HELLO_RESET).to.equal('READ_HELLO_RESET');
     });
   });
 

--- a/test/unit/reducers/read-one.js
+++ b/test/unit/reducers/read-one.js
@@ -1,10 +1,10 @@
 import simpleResource, {xhrStatuses} from '../../../src';
 
 describe('reducers: readOne', function() {
-  it('should handle `READ_ONE_HELLO`', () => {
+  it('should handle `READ_HELLO`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO',
+      type: 'READ_HELLO',
       id: 3
     });
 
@@ -22,10 +22,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_FAIL`', () => {
+  it('should handle `READ_HELLO_FAIL`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_FAIL',
+      type: 'READ_HELLO_FAIL',
       id: 3
     });
 
@@ -43,7 +43,7 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_SUCCEED`', () => {
+  it('should handle `READ_HELLO_SUCCEED`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -53,7 +53,7 @@ describe('reducers: readOne', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_SUCCEED',
+      type: 'READ_HELLO_SUCCEED',
       id: 3,
       resource: {
         id: 3,
@@ -80,7 +80,7 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_SUCCEED` with `replace: false`', () => {
+  it('should handle `READ_HELLO_SUCCEED` with `replace: false`', () => {
     const result = simpleResource('hello', {
       initialState: {
         resources: [
@@ -90,7 +90,7 @@ describe('reducers: readOne', function() {
     });
 
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_SUCCEED',
+      type: 'READ_HELLO_SUCCEED',
       id: 3,
       replace: false,
       resource: {
@@ -119,12 +119,12 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_SUCCEED` with a custom idAttribute', () => {
+  it('should handle `READ_HELLO_SUCCEED` with a custom idAttribute', () => {
     const result = simpleResource('hello', {
       idAttribute: 'whatPls'
     });
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_SUCCEED',
+      type: 'READ_HELLO_SUCCEED',
       whatPls: 3,
       resource: {
         whatPls: 3,
@@ -151,10 +151,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_ABORT`', () => {
+  it('should handle `READ_HELLO_ABORT`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_ABORT',
+      type: 'READ_HELLO_ABORT',
       id: 3
     });
 
@@ -172,10 +172,10 @@ describe('reducers: readOne', function() {
     });
   });
 
-  it('should handle `READ_ONE_HELLO_RESET`', () => {
+  it('should handle `READ_HELLO_RESET`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {
-      type: 'READ_ONE_HELLO_RESET',
+      type: 'READ_HELLO_RESET',
       id: 3
     });
 


### PR DESCRIPTION
@sprjr have been talking about the naming of action types in #42. We're not sure about whether we will keep `_MANY` for actions that affect more than one resource, but we did decide that we don't need the `_ONE` prefix, so that is what this PR removes.