### PR TITLE
Make "read" more consistent with other single actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ supports all of those actions. Sometimes, you won't need to support all CRUD
 actions on a resource. In those situations, you can use this to disable the
 creation of particular action types. The five CRUD actions are:
 
-- `readOne`
+- `read`
 - `readMany`
 - `create`
 - `update`
@@ -148,7 +148,7 @@ up to you.
 // "cat" resource.
 const cat = createResource('cat', {
   supportedActions: {
-    readOne: false,
+    read: false,
     readMany: true,
     del: false,
     update: false,

--- a/src/default-reducers/index.js
+++ b/src/default-reducers/index.js
@@ -1,5 +1,5 @@
 export * from './create';
-export * from './read-one';
+export * from './read';
 export * from './read-many';
 export * from './update';
 export * from './delete';

--- a/src/default-reducers/read.js
+++ b/src/default-reducers/read.js
@@ -2,7 +2,7 @@ import {
   updateResourceMeta, upsertResource, xhrStatuses
 } from '../utils';
 
-export function readOne(idAttr, state, action) {
+export function read(idAttr, state, action) {
   const resourceMeta = updateResourceMeta({
     resourceMeta: state.resourceMeta,
     newMeta: {retrievingStatus: xhrStatuses.PENDING},
@@ -16,7 +16,7 @@ export function readOne(idAttr, state, action) {
   };
 }
 
-export function readOneFail(idAttr, state, action) {
+export function readFail(idAttr, state, action) {
   const resourceMeta = updateResourceMeta({
     resourceMeta: state.resourceMeta,
     newMeta: {retrievingStatus: xhrStatuses.FAILED},
@@ -30,7 +30,7 @@ export function readOneFail(idAttr, state, action) {
   };
 }
 
-export function readOneSucceed(idAttribute, state, action) {
+export function readSucceed(idAttribute, state, action) {
   const resourceMeta = updateResourceMeta({
     resourceMeta: state.resourceMeta,
     newMeta: {retrievingStatus: xhrStatuses.SUCCEEDED},
@@ -53,7 +53,7 @@ export function readOneSucceed(idAttribute, state, action) {
   };
 }
 
-export function readOneAbort(idAttr, state, action) {
+export function readAbort(idAttr, state, action) {
   const resourceMeta = updateResourceMeta({
     resourceMeta: state.resourceMeta,
     newMeta: {retrievingStatus: xhrStatuses.ABORTED},
@@ -67,7 +67,7 @@ export function readOneAbort(idAttr, state, action) {
   };
 }
 
-export function readOneReset(idAttr, state, action) {
+export function readReset(idAttr, state, action) {
   const resourceMeta = updateResourceMeta({
     resourceMeta: state.resourceMeta,
     newMeta: {retrievingStatus: xhrStatuses.NULL},

--- a/src/generate-action-types.js
+++ b/src/generate-action-types.js
@@ -13,10 +13,10 @@ const mapConstant = (resourceName, crudAction) => ({
 export default (resourceName, pluralForm, supportedActions, customTypes) => {
   const capitalResourceName = resourceName.toUpperCase();
   const capitalPluralName = pluralForm.toUpperCase();
-  const {create, readOne, readMany, update, del} = supportedActions;
+  const {create, read, readMany, update, del} = supportedActions;
 
   const createTypes = create ? mapConstant(capitalResourceName, 'CREATE') : {};
-  const readOneTypes = readOne ? mapConstant(capitalResourceName, 'READ') : {};
+  const readTypes = read ? mapConstant(capitalResourceName, 'READ') : {};
   const readManyTypes = readMany ? mapConstant(capitalPluralName, 'READ_MANY') : {};
   const updateTypes = update ? mapConstant(capitalResourceName, 'UPDATE') : {};
   const deleteTypes = del ? mapConstant(capitalResourceName, 'DELETE') : {};
@@ -26,7 +26,7 @@ export default (resourceName, pluralForm, supportedActions, customTypes) => {
 
   return {
     ...createTypes,
-    ...readOneTypes,
+    ...readTypes,
     ...readManyTypes,
     ...updateTypes,
     ...deleteTypes,

--- a/src/generate-reducer.js
+++ b/src/generate-reducer.js
@@ -13,7 +13,7 @@ import * as defaultReducers from './default-reducers';
 function getActionReducers({actionReducers, resourceName, pluralForm, supportedActions, idAttr}) {
   const capitalResourceName = resourceName.toUpperCase();
   const capitalPluralName = pluralForm.toUpperCase();
-  const {create, readOne, readMany, update, del} = supportedActions;
+  const {create, read, readMany, update, del} = supportedActions;
 
   const createReducers = create ? {
     [`CREATE_${capitalResourceName}`]: defaultReducers.create.bind(null, idAttr),
@@ -23,12 +23,12 @@ function getActionReducers({actionReducers, resourceName, pluralForm, supportedA
     [`CREATE_${capitalResourceName}_RESET`]: defaultReducers.createReset.bind(null, idAttr)
   } : {};
 
-  const readOneReducers = readOne ? {
-    [`READ_${capitalResourceName}`]: defaultReducers.readOne.bind(null, idAttr),
-    [`READ_${capitalResourceName}_FAIL`]: defaultReducers.readOneFail.bind(null, idAttr),
-    [`READ_${capitalResourceName}_SUCCEED`]: defaultReducers.readOneSucceed.bind(null, idAttr),
-    [`READ_${capitalResourceName}_ABORT`]: defaultReducers.readOneAbort.bind(null, idAttr),
-    [`READ_${capitalResourceName}_RESET`]: defaultReducers.readOneReset.bind(null, idAttr)
+  const readReducers = read ? {
+    [`READ_${capitalResourceName}`]: defaultReducers.read.bind(null, idAttr),
+    [`READ_${capitalResourceName}_FAIL`]: defaultReducers.readFail.bind(null, idAttr),
+    [`READ_${capitalResourceName}_SUCCEED`]: defaultReducers.readSucceed.bind(null, idAttr),
+    [`READ_${capitalResourceName}_ABORT`]: defaultReducers.readAbort.bind(null, idAttr),
+    [`READ_${capitalResourceName}_RESET`]: defaultReducers.readReset.bind(null, idAttr)
   } : {};
 
   const readManyReducers = readMany ? {
@@ -55,10 +55,9 @@ function getActionReducers({actionReducers, resourceName, pluralForm, supportedA
     [`DELETE_${capitalResourceName}_RESET`]: defaultReducers.delReset.bind(null, idAttr)
   } : {};
 
-  // Default reducers manage the five states of CRUD.
   const allDefaultActionReducers = {
     ...createReducers,
-    ...readOneReducers,
+    ...readReducers,
     ...readManyReducers,
     ...updateReducers,
     ...deleteReducers,
@@ -79,6 +78,7 @@ export default function generateReducers(options) {
     if (!actionReducer) {
       return state;
     }
+
     const result = actionReducer(state, action);
     return result ? result : state;
   };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {
 
 const supportAllActions = {
   create: true,
-  readOne: true,
+  read: true,
   readMany: true,
   update: true,
   del: true

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,20 +8,7 @@ export const xhrStatuses = {
   NULL: 'NULL'
 };
 
-export const initialResourceMetaState = {
-  // The status of any existing request to update this resource
-  updatingStatus: xhrStatuses.NULL,
-  // The status of any existing request to fetch this resource
-  retrievingStatus: xhrStatuses.NULL,
-  // The status of an any existing request to delete this resource. Note that
-  // this will never be "SUCCEEDED," as a successful delete removes the
-  // resource from the store.
-  deletingStatus: xhrStatuses.NULL
-};
-
-// resourceMeta: the metadata Object from a resource store slice
-// resourceMeta: the new metadataObject from a given resourceMeta
-// id: the ID of the resource to be updated
+// Updates a single resource's metadata
 export function updateResourceMeta({resourceMeta, newMeta, id, replace}) {
   const existingMeta = replace ? {} : resourceMeta[id];
   return {
@@ -38,7 +25,7 @@ export function updateResourceMeta({resourceMeta, newMeta, id, replace}) {
 }
 
 // Similar to `updateResourceMeta`, but it accepts an array of IDs instead of
-// a single ID.
+// a single ID. Used for bulk updating meta.
 export function updateManyResourceMetas({resourceMeta, newMeta, ids, replace}) {
   const next = replace ? {} : {...resourceMeta};
 
@@ -53,9 +40,7 @@ export function updateManyResourceMetas({resourceMeta, newMeta, ids, replace}) {
   return next;
 }
 
-// resources: the Array of resources
-// resource: the new resource object to be added or updated
-// id: the ID of the resource being updated
+// Insert a new resource or update an existing resource.
 export function upsertResource({resources, resource, id, idAttribute, replace}) {
   // Attempt to find the resource by its ID. If the ID doesn't exist, or if
   // no resource by that ID exists, then we append it to the end as a new
@@ -84,6 +69,7 @@ export function upsertResource({resources, resource, id, idAttribute, replace}) 
   return shallowClone;
 }
 
+// Similar to `upsertResource`, but for many resources.
 export function upsertManyResources({resources, newResources, idAttribute, replace}) {
   const shallowClone = replace ? [] : [...resources];
 
@@ -111,6 +97,17 @@ export function upsertManyResources({resources, newResources, idAttribute, repla
 
   return shallowClone;
 }
+
+export const initialResourceMetaState = {
+  // The status of any existing request to update this resource
+  updatingStatus: xhrStatuses.NULL,
+  // The status of any existing request to fetch this resource
+  retrievingStatus: xhrStatuses.NULL,
+  // The status of an any existing request to delete this resource. Note that
+  // this will never be "SUCCEEDED," as a successful delete removes the
+  // resource from the store.
+  deletingStatus: xhrStatuses.NULL
+};
 
 export function generateDefaultInitialState() {
   return {

--- a/test/unit/action-types.js
+++ b/test/unit/action-types.js
@@ -18,7 +18,7 @@ describe('actionTypes', function() {
     });
   });
 
-  describe('readOne', () => {
+  describe('read', () => {
     it('should have the right actionTypes', () => {
       const actionTypes = simpleResource('hello').actionTypes;
       expect(actionTypes.READ_HELLO).to.equal('READ_HELLO');
@@ -84,7 +84,7 @@ describe('actionTypes', function() {
         supportedActions: {
           create: false,
           readMany: true,
-          readOne: false,
+          read: false,
           update: false,
           del: false
         }

--- a/test/unit/reducers/read.js
+++ b/test/unit/reducers/read.js
@@ -1,6 +1,6 @@
 import simpleResource, {xhrStatuses} from '../../../src';
 
-describe('reducers: readOne', function() {
+describe('reducers: read', function() {
   it('should handle `READ_HELLO`', () => {
     const result = simpleResource('hello');
     const reduced = result.reducer(result.initialState, {


### PR DESCRIPTION
Removes all usage of "readOne" from the source and library